### PR TITLE
remove hard-coded parameter from main.cpp

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -19,6 +19,17 @@
 #define SAMPLING_TIME (0.008)
 
 /*
+*AHRS config
+*/
+#define MAGNETOMETER_BIAS_X 222.566
+#define MAGNETOMETER_BIAS_Y 41.087
+#define MAGNETOMETER_BIAS_Z -60.268
+
+#define MAGNETOMETER_SCALE_X 1.050
+#define MAGNETOMETER_SCALE_Y 0.936
+#define MAGNETOMETER_SCALE_Z 1.022
+
+/*
  * Motors config
  */
 #define FRONT_LEFT_ESC_PIN 33
@@ -49,6 +60,21 @@
 /* Maximum yaw rate (rad/s) 10 deg/s = 0.1745 rad/s */
 #define RADIO_MAX_YAW_RATE_RAD_SEC 0.1745
 
+/** Trimmer A on RC - maximum quaternion XY gain */
+#define RADIO_TRIMMER_MAX_QUATERNION_XY_GAIN 100.
+
+/** Trimmer B on RC - maximum quaternion Z gain */
+#define RADIO_TRIMMER_MAX_QUATERNION_Z_GAIN 20.
+
+/** Trimmer C on RC - maximum omega xy gain */
+#define RADIO_TRIMMER_MAX_OMEGA_XY_GAIN 0.5
+
+/** Trimmer E on RC - maximum omega z gain */
+#define RADIO_TRIMMER_MAX_OMEGA_Z_GAIN 0.05
+
+/**
+ * Control action to PWM scaling factor
+ */
 #define U_TO_PWM 8
 
 #ifndef BZZZ_VERBOSITY

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -19,8 +19,8 @@
 #define SAMPLING_TIME (0.008)
 
 /*
-*AHRS config
-*/
+ * AHRS config
+ */
 #define MAGNETOMETER_BIAS_X 222.566
 #define MAGNETOMETER_BIAS_Y 41.087
 #define MAGNETOMETER_BIAS_Z -60.268

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,8 +115,8 @@ void setupAHRS()
 {
   ahrs.setup();
   ahrs.preflightCalibrate(false);
-  // TODO create #define's with these parameters
-  ahrs.calibrateMagnetometer(222.566, 41.087, -60.268, 1.050, 0.936, 1.022);
+  ahrs.calibrateMagnetometer(MAGNETOMETER_BIAS_X, MAGNETOMETER_BIAS_Y, MAGNETOMETER_BIAS_Z, 
+                             MAGNETOMETER_SCALE_X, MAGNETOMETER_SCALE_X, MAGNETOMETER_SCALE_X);
 }
 
 /**
@@ -169,11 +169,11 @@ void loop()
   ahrs.update();
 
   controller.setQuaternionGains(
-      -radio.trimmerVRAPercentage() * 100.,
-      -radio.trimmerVRBPercentage() * 20.);
+      -radio.trimmerVRAPercentage() * RADIO_TRIMMER_MAX_QUATERNION_XY_GAIN,
+      -radio.trimmerVRBPercentage() * RADIO_TRIMMER_MAX_QUATERNION_Z_GAIN);
   controller.setAngularVelocityGains(
-      -radio.trimmerVRCPercentage() * 0.5,
-      -radio.trimmerVREPercentage() * 0.05);
+      -radio.trimmerVRCPercentage() * RADIO_TRIMMER_MAX_OMEGA_XY_GAIN,
+      -radio.trimmerVREPercentage() * RADIO_TRIMMER_MAX_OMEGA_Z_GAIN);
 
   ahrs.quaternion(quaternionImuData);
   ahrs.angularVelocity(angularVelocity);
@@ -192,8 +192,9 @@ void loop()
 
   controller.controlAction(attitudeError, angularVelocity, controls);
 
-  // TODO Remove hard-coded numbers from here
-  float throttleFromRadio = radio.throttleReferencePercentage() * 1000 + 1000;
+    float throttleFromRadio = (radio.throttleReferencePercentage() 
+                              * (ABSOLUTE_MAX_PWM - ZERO_ROTOR_SPEED) 
+                              + ZERO_ROTOR_SPEED);
 
   // Compute control actions and send them to the motors
   int motorFL, motorFR, motorBL, motorBR;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -115,7 +115,7 @@ void setupAHRS()
 {
   ahrs.setup();
   ahrs.preflightCalibrate(false);
-  ahrs.calibrateMagnetometer(MAGNETOMETER_BIAS_X, MAGNETOMETER_BIAS_Y, MAGNETOMETER_BIAS_Z, 
+  ahrs.calibrateMagnetometer(MAGNETOMETER_BIAS_X, MAGNETOMETER_BIAS_Y, MAGNETOMETER_BIAS_Z,
                              MAGNETOMETER_SCALE_X, MAGNETOMETER_SCALE_X, MAGNETOMETER_SCALE_X);
 }
 
@@ -192,9 +192,7 @@ void loop()
 
   controller.controlAction(attitudeError, angularVelocity, controls);
 
-    float throttleFromRadio = (radio.throttleReferencePercentage() 
-                              * (ABSOLUTE_MAX_PWM - ZERO_ROTOR_SPEED) 
-                              + ZERO_ROTOR_SPEED);
+  float throttleFromRadio = (radio.throttleReferencePercentage() * (ABSOLUTE_MAX_PWM - ZERO_ROTOR_SPEED) + ZERO_ROTOR_SPEED);
 
   // Compute control actions and send them to the motors
   int motorFL, motorFR, motorBL, motorBR;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,7 +192,7 @@ void loop()
 
   controller.controlAction(attitudeError, angularVelocity, controls);
 
-  float throttleFromRadio = (radio.throttleReferencePercentage() * (ABSOLUTE_MAX_PWM - ZERO_ROTOR_SPEED) + ZERO_ROTOR_SPEED);
+  float throttleFromRadio = radio.throttleReferencePercentage() * (ABSOLUTE_MAX_PWM - ZERO_ROTOR_SPEED) + ZERO_ROTOR_SPEED;
 
   // Compute control actions and send them to the motors
   int motorFL, motorFR, motorBL, motorBR;


### PR DESCRIPTION
## Main Changes
* Removed hard-coded magnetometer parameters from `main.cpp`
* Removed hard-coded trimmer parameters from `main.cpp`

Tested on hardware and works

## Associated Issues

- Closes #40


