### PR TITLE
Fixed incompatibility between ThreeWaySwitch and bit shift operator.

### DIFF
--- a/raspberry/read_sbus/radioDataParser.py
+++ b/raspberry/read_sbus/radioDataParser.py
@@ -134,10 +134,10 @@ class RadioDataParser:
         """
         self.switchValue = self.m_channelData[RADIO_CHANNEL_SWITCH_C]
         if self.switchValue <= 450:
-            return ThreeWaySwitch.DOWN
+            return ThreeWaySwitch.DOWN.value
         elif self.switchValue <= 1200:
-            return ThreeWaySwitch.MID
-        return ThreeWaySwitch.UP
+            return ThreeWaySwitch.MID.value
+        return ThreeWaySwitch.UP.value
 
     def switch_D(self):
         """Checks the positon of the switch D.

--- a/raspberry/read_sbus/read_sbus_from_GPIO_receiver.py
+++ b/raspberry/read_sbus/read_sbus_from_GPIO_receiver.py
@@ -121,4 +121,3 @@ def run_thread_every_given_interval(interval,
 
 # Run the get_radio_data_parse_and_send_to_ESP funtionn @ 50Hz
 run_thread_every_given_interval(0.02, get_radio_data_parse_and_send_to_ESP)
-


### PR DESCRIPTION
## Main Changes
There was a logical error in `radioDataParser.py`, which is trying to do a bitwise operation directly on the `ThreeWaySwitch` instead of its `value`. Fixed it now.