### PR TITLE
fixed small typo in main.cpp

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,7 +27,7 @@ void setupAHRS()
   ahrs.setup();
   ahrs.preflightCalibrate(false);
   ahrs.calibrateMagnetometer(MAGNETOMETER_BIAS_X, MAGNETOMETER_BIAS_Y, MAGNETOMETER_BIAS_Z,
-                             MAGNETOMETER_SCALE_X, MAGNETOMETER_SCALE_X, MAGNETOMETER_SCALE_X);
+                             MAGNETOMETER_SCALE_X, MAGNETOMETER_SCALE_Y, MAGNETOMETER_SCALE_Z);
 }
 
 /**


### PR DESCRIPTION
fixed small typo in [src/main.cpp](https://github.com/QUB-ASL/bzzz/blob/main/src/main.cpp) line 28

- Closes #94
