### PR TITLE
update setup.py and platformio.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -38,6 +38,6 @@ build_flags =
 ; Dependencies
 lib_deps = 
 	hideakitai/MPU9250@^0.4.8
-	roboticsbrno/ServoESP32@^1.0.3
+	roboticsbrno/ServoESP32@1.0.3
 
 

--- a/raspberry/setup.py
+++ b/raspberry/setup.py
@@ -36,10 +36,7 @@ setup(name=NAME,
           exclude=["tests/"]),
       include_package_data=True,
       install_requires=[
-          'smbus', 'pigpio', 'bitarray', 'pyserial', 'VL53L0X', 'pandas', 'numpy', 'matplotlib', 'wheel', 'control'
-      ],
-      dependency_links=[
-          "git+https://github.com/pimoroni/VL53L0X-python.git",
+          'smbus', 'pigpio', 'bitarray', 'pyserial', 'VL53L0X @ git+https://github.com/pimoroni/VL53L0X-python.git', 'pandas', 'numpy', 'matplotlib', 'wheel', 'control'
       ],
       classifiers=[
           'Topic :: Software Development :: Embedded Systems'

--- a/raspberry/setup.py
+++ b/raspberry/setup.py
@@ -36,7 +36,7 @@ setup(name=NAME,
           exclude=["tests/"]),
       include_package_data=True,
       install_requires=[
-          'smbus', 'bitarray', 'pyserial', 'VL53L0X @ git+https://github.com/pimoroni/VL53L0X-python.git', 'pandas', 'numpy', 'matplotlib', 'wheel', 'control'
+          'pigpio', 'smbus', 'bitarray', 'pyserial', 'VL53L0X @ git+https://github.com/pimoroni/VL53L0X-python.git', 'pandas', 'numpy', 'matplotlib', 'control'
       ],
       classifiers=[
           'Topic :: Software Development :: Embedded Systems'

--- a/raspberry/setup.py
+++ b/raspberry/setup.py
@@ -36,7 +36,7 @@ setup(name=NAME,
           exclude=["tests/"]),
       include_package_data=True,
       install_requires=[
-          'smbus', 'pigpio', 'bitarray', 'pyserial', 'VL53L0X @ git+https://github.com/pimoroni/VL53L0X-python.git', 'pandas', 'numpy', 'matplotlib', 'wheel', 'control'
+          'smbus', 'bitarray', 'pyserial', 'VL53L0X @ git+https://github.com/pimoroni/VL53L0X-python.git', 'pandas', 'numpy', 'matplotlib', 'wheel', 'control'
       ],
       classifiers=[
           'Topic :: Software Development :: Embedded Systems'

--- a/raspberry/setup.py
+++ b/raspberry/setup.py
@@ -36,7 +36,7 @@ setup(name=NAME,
           exclude=["tests/"]),
       include_package_data=True,
       install_requires=[
-          'pigpio', 'smbus', 'bitarray', 'pyserial', 'VL53L0X @ git+https://github.com/pimoroni/VL53L0X-python.git', 'pandas', 'numpy', 'matplotlib', 'control'
+          'pigpio', 'smbus', 'bitarray', 'pyserial', 'VL53L0X @ git+https://github.com/pimoroni/VL53L0X-python.git', 'pandas', 'numpy==1.24', 'control'
       ],
       classifiers=[
           'Topic :: Software Development :: Embedded Systems'


### PR DESCRIPTION
## Main Changes

New versions of `pip` no longer use `dependency_links` therefore the `setup.py` file has been updated to fix this issue


## Associated Issues

- Closes #144 


## Tests

This has been tested and works on Raspbery Pi OS bookworm with `pip 23.0.1`
