### PR TITLE
Refuse to arm unless throttle stick is down and switches are at the correct positions

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -93,6 +93,7 @@
  * Fail-safe config
 */
 #define TX_CONNECTION_TIMEOUT_IN_uS 500000
+#define UN_KILL_KILL_SWITCH_TIMEOUT_IN_ms 3000
 
 #ifndef BZZZ_LOGGING_LEVEL
 #define BZZZ_LOGGING_LEVEL 3

--- a/include/config.hpp
+++ b/include/config.hpp
@@ -48,6 +48,12 @@
  */
 #define BUZZER_PIN 27
 
+/**
+ * Maximum throttle percentage for arming the motors
+ * The throttle stick must be less than this percentage to arm the motors
+ */
+#define MAX_ARMING_THROTTLE_PERCENTAGE 0.05
+
 /** Maximum pitch value corresponding to the top position of the stick (30deg = 0.52rad) */
 #define PITCH_MAX_RAD 0.5235987755982988
 

--- a/include/raspberryEsp32Interface.hpp
+++ b/include/raspberryEsp32Interface.hpp
@@ -111,6 +111,11 @@ namespace bzzz
         float yawRateReferenceRadSec();
 
         /**
+         * @brief value of switch A
+         */
+        bool switchA();
+
+        /**
          * @brief whether the arm switch is on
          */
         bool armed();

--- a/include/raspberryEsp32Interface.hpp
+++ b/include/raspberryEsp32Interface.hpp
@@ -116,9 +116,12 @@ namespace bzzz
         bool switchA();
 
         /**
-         * @brief whether the arm switch is on
+         * @brief whether the motors can be armed
+         *
+         * For the motors to arm, the arm switch needs to be at the ON position
+         * and the throttle stick must be down.
          */
-        bool armed();
+        bool canArm();
 
         /**
          * @brief whether the kill switch is on

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include "controller.hpp"
 #include "fail_safes.hpp"
 #include "util.hpp"
-int PreviousKill=0;
+
 using namespace bzzz;
 
 MotorDriver motorDriver;
@@ -20,7 +20,7 @@ float yawReferenceRad = 0.0;
 float initialAngularVelocity[3];
 float IMUData[6];
 int motorFL, motorFR, motorBL, motorBR;
-
+int PreviousKill=0;
 /**
  * Setup the AHRS
  */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,7 +7,7 @@
 #include "controller.hpp"
 #include "fail_safes.hpp"
 #include "util.hpp"
-
+int PreviousKill=0;
 using namespace bzzz;
 
 MotorDriver motorDriver;
@@ -93,6 +93,7 @@ void loop()
   {
     motorDriver.disarm();
     logSerial(LogVerbosityLevel::Debug, "Exit loop!");
+    PreviousKill=1;
     return; // exit the loop
   }
 
@@ -139,12 +140,24 @@ void loop()
   float throttleRef = raspberryEsp32Interface.throttleReferencePWM();
 
   // Compute control actions and send them to the motors
-  controller.motorPwmSignals(attitudeError,
+  if(PreviousKill==0)
+  {
+      controller.motorPwmSignals(attitudeError,
                              angularVelocityCorrected,
                              yawRateReference,
                              throttleRef,
                              motorFL, motorFR, motorBL, motorBR);
-  motorDriver.writeSpeedToEsc(motorFL, motorFR, motorBL, motorBR);
+      motorDriver.writeSpeedToEsc(motorFL, motorFR, motorBL, motorBR);
+  }
+  else 
+  {
+      controller.motorPwmSignals(attitudeError,
+                             angularVelocityCorrected,
+                             yawRateReference,
+                             throttleRef,
+                             motorFL, motorFR, motorBL, motorBR);
+      motorDriver.writeSpeedToEsc(1000, 1000, 1000, 1000);
+  }
 
   logSerial(LogVerbosityLevel::Debug, "PR: %f %f\n",
             IMUData[1], IMUData[2]);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,7 +24,6 @@ bool wasKill=0;
 bool isKill=0;
 unsigned long timestampLastKill = 0;
 bool isThrottleStickDown = 0;
-bool allowUnkill=1;
 
 /**
  * Setup the AHRS
@@ -107,17 +106,12 @@ void loop()
   if (!isKill && wasKill){
     // If you're too late, you need to pull the stick down
     unsigned long timeElapsedSinceKill = millis() - timestampLastKill;
-    if (timeElapsedSinceKill >= 3000) {
-        logSerial(LogVerbosityLevel::Debug, "ET: %lu, isThrottleStickDown: %d\n", timeElapsedSinceKill, isThrottleStickDown);
-        if (isThrottleStickDown){
-          // proceed - unkill
-        } else { 
+    if (timeElapsedSinceKill >= UN_KILL_KILL_SWITCH_TIMEOUT_IN_ms) {
+        if (!isThrottleStickDown){
           motorDriver.disarm();
           isKill = 1;
           return;
         }
-    } else {
-      // just procceed - unkill 
     }
   } 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -76,6 +76,10 @@ void setGainsFromRcTrimmers()
  */
 void loop()
 {
+  if (raspberryEsp32Interface.throttleReferencePercentage() < MAX_ARMING_THROTTLE_PERCENTAGE)
+  {
+    PreviousKill=0;
+  }
   float quaternionImuData[4];
   float measuredAngularVelocity[3];
   float angularVelocityCorrected[3];

--- a/src/radio.cpp
+++ b/src/radio.cpp
@@ -195,7 +195,10 @@ namespace bzzz
     {
         float temp[6];
         readPiData();
-        sendFlightDataToPi(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
+        if(RADIO_SWITCH_A_BIT==0b01000 && RADIO_SWITCH_B_BIT==0b10000 && RADIO_SWITCH_C_BITS==0b00110 && RADIO_SWITCH_D_BIT==0b00001)
+        {
+            sendFlightDataToPi(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1); /*if the postions are not right do nothing*/
+        }
         delay(20);
         while (!armed())
         {

--- a/src/raspberryEsp32Interface.cpp
+++ b/src/raspberryEsp32Interface.cpp
@@ -148,14 +148,22 @@ namespace bzzz
     float RaspberryEsp32Interface::throttleReferencePercentage()
     {
         // Since PWM range is [1000, 2000], we subtract 1000 to calculate the percentage
-        //   percentage = (Referance_PWM - 1000)/1000
+        //   percentage = (Reference_PWM - 1000)/1000
         //=> percentage = Reference_PWM/1000 - 1
         return m_refData[RADIO_CHANNEL_THROTTLE] / 1000 - 1;
     }
 
+    bool RaspberryEsp32Interface::switchA()
+    {
+        return m_encodedSwitchesData & RADIO_SWITCH_A_BIT;
+    }
+    
     bool RaspberryEsp32Interface::armed()
     {
-        return m_encodedSwitchesData == RADIO_SWITCH_B_BIT && throttleReferencePercentage() < 0.05 ;
+        bool isOnlyArmSwitchOn = m_encodedSwitchesData == RADIO_SWITCH_B_BIT;
+        bool isThrottleDown = throttleReferencePercentage() < MAX_ARMING_THROTTLE_PERCENTAGE;
+
+        return isOnlyArmSwitchOn && isThrottleDown;;
     }
 
     bool RaspberryEsp32Interface::kill()

--- a/src/raspberryEsp32Interface.cpp
+++ b/src/raspberryEsp32Interface.cpp
@@ -160,6 +160,10 @@ namespace bzzz
     
     bool RaspberryEsp32Interface::armed()
     {
+        // We only want to arm the motor when the arm switch is down and the rest are up 
+        // therefore we want the m_encodedSwitchesData == RADIO_SWITCH_B_BIT.
+        // We also only want to arm when the throttle is down
+        // therefore throttleReferencePercentage() < MAX_ARMING_THROTTLE_PERCENTAGE (default 5%)
         bool isOnlyArmSwitchOn = m_encodedSwitchesData == RADIO_SWITCH_B_BIT;
         bool isThrottleDown = throttleReferencePercentage() < MAX_ARMING_THROTTLE_PERCENTAGE;
 

--- a/src/raspberryEsp32Interface.cpp
+++ b/src/raspberryEsp32Interface.cpp
@@ -158,7 +158,7 @@ namespace bzzz
         return m_encodedSwitchesData & RADIO_SWITCH_A_BIT;
     }
     
-    bool RaspberryEsp32Interface::armed()
+    bool RaspberryEsp32Interface::canArm()
     {
         // We only want to arm the motor when the arm switch is down and the rest are up 
         // therefore we want the m_encodedSwitchesData == RADIO_SWITCH_B_BIT.
@@ -221,7 +221,7 @@ namespace bzzz
         readPiData();
         sendFlightDataToPi(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
         delay(20);
-        while (!armed())
+        while (!canArm())
         {
             readPiData();
             sendFlightDataToPi(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1);

--- a/src/raspberryEsp32Interface.cpp
+++ b/src/raspberryEsp32Interface.cpp
@@ -155,7 +155,7 @@ namespace bzzz
 
     bool RaspberryEsp32Interface::armed()
     {
-        return m_encodedSwitchesData & RADIO_SWITCH_B_BIT;
+        return m_encodedSwitchesData == RADIO_SWITCH_B_BIT && throttleReferencePercentage() < 0.05 ;
     }
 
     bool RaspberryEsp32Interface::kill()
@@ -207,10 +207,7 @@ namespace bzzz
     {
         float temp[6];
         readPiData();
-        if(RADIO_SWITCH_A_BIT==0b01000 && RADIO_SWITCH_B_BIT==0b10000 && RADIO_SWITCH_C_BITS==0b00110 && RADIO_SWITCH_D_BIT==0b00001)
-        {
-            sendFlightDataToPi(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1); /*if the postions are not right do nothing*/
-        }
+        sendFlightDataToPi(-1, -1, -1, -1, -1, -1, -1, -1, -1, -1);
         delay(20);
         while (!armed())
         {


### PR DESCRIPTION
## Main Changes

The quadcopter will not arm unless all switches are up except the arm switch (switch B) and the throttle is less than 5%


## Associated Issues

Closes #110 


## Tests

Test that quadcopter will not arm 

