### PR TITLE
Update maximum attitude gains from trimmers and attitude gains

### DIFF
--- a/include/config.hpp
+++ b/include/config.hpp
@@ -69,14 +69,14 @@
 #define RADIO_TRIMMER_MAX_QUATERNION_Z_GAIN 100.
 
 /** Trimmer C on RC - maximum omega xy gain */
-#define RADIO_TRIMMER_MAX_OMEGA_XY_GAIN 0.5
+#define RADIO_TRIMMER_MAX_OMEGA_XY_GAIN 0.3
 /** Tested attitude angular velocity roll-pitch axis control gain*/
-#define OMEGA_XY_GAIN 0.266
+#define OMEGA_XY_GAIN 0.305
 
 /** Trimmer E on RC - maximum omega z gain */
-#define RADIO_TRIMMER_MAX_OMEGA_Z_GAIN 10
+#define RADIO_TRIMMER_MAX_OMEGA_Z_GAIN 4
 /** Tested attitude angular velocity yaw axis control gain*/
-#define OMEGA_Z_GAIN 0.145
+#define OMEGA_Z_GAIN 0.111
 
 /**
  * Control action to PWM scaling factor

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,11 +64,11 @@ void setup()
 void setGainsFromRcTrimmers()
 {
   controller.setQuaternionGain(
-      -QUATERNION_XY_GAIN * RADIO_TRIMMER_MAX_QUATERNION_XY_GAIN);
+      -raspberryEsp32Interface.trimmerVRAPercentage() * RADIO_TRIMMER_MAX_QUATERNION_XY_GAIN);
   controller.setAngularVelocityXYGain(
-      -OMEGA_XY_GAIN * RADIO_TRIMMER_MAX_OMEGA_XY_GAIN);
+      -raspberryEsp32Interface.trimmerVRBPercentage() * RADIO_TRIMMER_MAX_OMEGA_XY_GAIN);
   controller.setYawAngularVelocityGain(
-      -OMEGA_Z_GAIN * RADIO_TRIMMER_MAX_OMEGA_Z_GAIN);
+      -raspberryEsp32Interface.trimmerVRCPercentage() * RADIO_TRIMMER_MAX_OMEGA_Z_GAIN);
 }
 
 /**


### PR DESCRIPTION
## Main Changes

Changed the `main.cpp` to use the trimmers to set the attitude gains
Updated the max angular velocity gains
Updated the hard set angular velocity gains

## Associated Issues

- Closes #183 


## Tests
This has been tested on the Quadcopter when flying manually and not using altitude hold.
The altitude hold also uses the trimmers so maybe we would be better hard setting these values again?
What's your thoughts
