### PR TITLE
Timestamp Slowdown

### DIFF
--- a/raspberry/bzzz/sensors/data_logger.py
+++ b/raspberry/bzzz/sensors/data_logger.py
@@ -16,8 +16,9 @@ class DataLogger:
         """
         self.__data_vault = np.zeros(
             (max_samples, num_features), dtype=np.float64)
+        # Allocate an array based on how many timestamps there will be
         self.__timestamps_vault = np.array(
-            [datetime.datetime.now()] * max_samples)
+            [datetime.datetime.min] * max_samples)
         self.__feature_names = feature_names
         self.__cursor = 0
 
@@ -29,7 +30,7 @@ class DataLogger:
         :param datum: measurement (float or numpy array)
         """
         self.__data_vault[self.__cursor, :] = datum
-        self.__timestamps_vault[self.__cursor:] = timespamp
+        self.__timestamps_vault[self.__cursor] = timespamp
         self.__cursor = self.__cursor + 1
 
     def save_to_csv(self, filename):

--- a/raspberry/bzzz/sensors/data_logger.py
+++ b/raspberry/bzzz/sensors/data_logger.py
@@ -22,7 +22,7 @@ class DataLogger:
         self.__feature_names = feature_names
         self.__cursor = 0
 
-    def record(self, timespamp, datum):
+    def record(self, timestamp, datum):
         """
         Record/log data in memory
 
@@ -30,7 +30,7 @@ class DataLogger:
         :param datum: measurement (float or numpy array)
         """
         self.__data_vault[self.__cursor, :] = datum
-        self.__timestamps_vault[self.__cursor] = timespamp
+        self.__timestamps_vault[self.__cursor] = timestamp
         self.__cursor = self.__cursor + 1
 
     def save_to_csv(self, filename):


### PR DESCRIPTION
## Main Changes

Increasing the size of the max samples causes delays when trying read the most up to date values.
This is due to writing to the entirety of the timestamp array every time a new sensor reading was recorded.
This bug has been fixed

## Associated Issues

- Closes #235
- Addresses the `time.sleep(0.018)` needed in `main.py` issue mentioned in PR #215


## Tests

This has been tested with the Evo ToF sensor and anemometer on the quadcopter.
A test was also carried out to check it would fix `time.sleep(0.018)` needed in `main.py` 
